### PR TITLE
Resuming remote writing from a last marked segment

### DIFF
--- a/storage/remote/marker_file_handler.go
+++ b/storage/remote/marker_file_handler.go
@@ -47,6 +47,7 @@ func NewMarkerFileHandler(logger log.Logger, walDir, markerId string) (MarkerFil
 		lastMarkedSegmentFilePath: filepath.Join(markerDir, "segment"),
 	}
 
+	//TODO: Should this be in a separate Start() function?
 	go mfh.markSegmentAsync()
 
 	return mfh, nil

--- a/storage/remote/marker_file_handler.go
+++ b/storage/remote/marker_file_handler.go
@@ -1,0 +1,131 @@
+package remote
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/prometheus/tsdb/fileutil"
+	"github.com/prometheus/prometheus/tsdb/wlog"
+)
+
+type MarkerFileHandler interface {
+	wlog.Marker
+	MarkSegment(segment int)
+	Stop()
+}
+
+type markerFileHandler struct {
+	segmentToMark chan int
+	quit          chan struct{}
+
+	logger log.Logger
+
+	lastMarkedSegmentFilePath string
+}
+
+var (
+	_ MarkerFileHandler = (*markerFileHandler)(nil)
+)
+
+func NewMarkerFileHandler(logger log.Logger, walDir, markerId string) (MarkerFileHandler, error) {
+	markerDir := filepath.Join(walDir, "remote", markerId)
+
+	dir := filepath.Join(walDir, "remote", markerId)
+	if err := os.MkdirAll(dir, 0o777); err != nil {
+		return nil, fmt.Errorf("error creating segment marker folder %q: %w", dir, err)
+	}
+
+	mfh := &markerFileHandler{
+		segmentToMark:             make(chan int, 1),
+		quit:                      make(chan struct{}),
+		logger:                    logger,
+		lastMarkedSegmentFilePath: filepath.Join(markerDir, "segment"),
+	}
+
+	go mfh.markSegmentAsync()
+
+	return mfh, nil
+}
+
+// LastMarkedSegment implements wlog.Marker.
+func (mfh *markerFileHandler) LastMarkedSegment() int {
+	bb, err := ioutil.ReadFile(mfh.lastMarkedSegmentFilePath)
+	if os.IsNotExist(err) {
+		level.Warn(mfh.logger).Log("msg", "marker segment file does not exist", "file", mfh.lastMarkedSegmentFilePath)
+		return -1
+	} else if err != nil {
+		level.Error(mfh.logger).Log("msg", "could not access segment marker file", "file", mfh.lastMarkedSegmentFilePath, "err", err)
+		return -1
+	}
+
+	savedSegment, err := strconv.Atoi(string(bb))
+	if err != nil {
+		level.Error(mfh.logger).Log("msg", "could not read segment marker file", "file", mfh.lastMarkedSegmentFilePath, "err", err)
+		return -1
+	}
+
+	if savedSegment < 0 {
+		level.Error(mfh.logger).Log("msg", "invalid segment number inside marker file", "file", mfh.lastMarkedSegmentFilePath, "segment number", savedSegment)
+		return -1
+	}
+
+	return savedSegment
+}
+
+// MarkSegment implements MarkerHandler.
+func (mfh *markerFileHandler) MarkSegment(segment int) {
+	var (
+		segmentText = strconv.Itoa(segment)
+		tmp         = mfh.lastMarkedSegmentFilePath + ".tmp"
+	)
+
+	if err := os.WriteFile(tmp, []byte(segmentText), 0o666); err != nil {
+		level.Error(mfh.logger).Log("msg", "could not create segment marker file", "file", tmp, "err", err)
+		return
+	}
+	if err := fileutil.Replace(tmp, mfh.lastMarkedSegmentFilePath); err != nil {
+		level.Error(mfh.logger).Log("msg", "could not replace segment marker file", "file", mfh.lastMarkedSegmentFilePath, "err", err)
+		return
+	}
+
+	level.Debug(mfh.logger).Log("msg", "updated segment marker file", "file", mfh.lastMarkedSegmentFilePath, "segment", segment)
+}
+
+// Stop implements MarkerHandler.
+func (mfh *markerFileHandler) Stop() {
+	level.Debug(mfh.logger).Log("msg", "waiting for marker file handler to shut down...")
+	mfh.quit <- struct{}{}
+}
+
+func (mfh *markerFileHandler) markSegmentAsync() {
+	for {
+		select {
+		case segmentToMark := <-mfh.segmentToMark:
+			if segmentToMark >= 0 {
+				var (
+					segmentText = strconv.Itoa(segmentToMark)
+					tmp         = mfh.lastMarkedSegmentFilePath + ".tmp"
+				)
+
+				if err := os.WriteFile(tmp, []byte(segmentText), 0o666); err != nil {
+					level.Error(mfh.logger).Log("msg", "could not create segment marker file", "file", tmp, "err", err)
+					return
+				}
+				if err := fileutil.Replace(tmp, mfh.lastMarkedSegmentFilePath); err != nil {
+					level.Error(mfh.logger).Log("msg", "could not replace segment marker file", "file", mfh.lastMarkedSegmentFilePath, "err", err)
+					return
+				}
+
+				level.Debug(mfh.logger).Log("msg", "updated segment marker file", "file", mfh.lastMarkedSegmentFilePath, "segment", segmentToMark)
+			}
+		case <-mfh.quit:
+			level.Debug(mfh.logger).Log("msg", "quitting marker handler")
+			return
+		}
+	}
+}

--- a/storage/remote/marker_handler.go
+++ b/storage/remote/marker_handler.go
@@ -1,0 +1,112 @@
+package remote
+
+import (
+	"sync"
+
+	"github.com/prometheus/prometheus/tsdb/wlog"
+)
+
+type MarkerHandler interface {
+	wlog.Marker
+	UpdatePendingData(dataCount, dataSegment int)
+	ProcessConsumedData(data map[int]int)
+	Stop()
+}
+
+type markerHandler struct {
+	markerFileHandler   MarkerFileHandler
+	pendingDataMut      sync.Mutex
+	latestDataSegment   int
+	lastMarkedSegment   int
+	pendingDataSegments map[int]int // Map of segment index to pending count
+}
+
+var (
+	_ MarkerHandler = (*markerHandler)(nil)
+)
+
+func NewMarkerHandler(mfh MarkerFileHandler) MarkerHandler {
+	mh := &markerHandler{
+		latestDataSegment:   -1,
+		lastMarkedSegment:   -1,
+		pendingDataSegments: make(map[int]int),
+		markerFileHandler:   mfh,
+	}
+
+	// Load the last marked segment from disk (if it exists).
+	if lastSegment := mh.markerFileHandler.LastMarkedSegment(); lastSegment >= 0 {
+		mh.lastMarkedSegment = lastSegment
+	}
+
+	return mh
+}
+
+func (mh *markerHandler) LastMarkedSegment() int {
+	return mh.markerFileHandler.LastMarkedSegment()
+}
+
+// updatePendingData updates a counter for how much data is yet to be sent from each segment.
+// "dataCount" will be added to the segment with ID "dataSegment".
+func (mh *markerHandler) UpdatePendingData(dataCount, dataSegment int) {
+	mh.pendingDataMut.Lock()
+	defer mh.pendingDataMut.Unlock()
+
+	mh.pendingDataSegments[dataSegment] += dataCount
+
+	// We want to save segments whose data has been fully processed by the
+	// QueueManager. To avoid too much overhead when appending data, we'll only
+	// examine pending data per segment whenever a new segment is detected.
+	//
+	// This could cause our saved segment to lag behind multiple segments
+	// depending on the rate that new segments are created and how long
+	// data in other segments takes to be processed.
+	if dataSegment <= mh.latestDataSegment {
+		return
+	}
+
+	// We've received data for a new segment. We'll use this as a signal to see
+	// if older segments have been fully processed.
+	//
+	// We want to mark the highest segment which has no more pending data and is
+	// newer than our last mark.
+	mh.latestDataSegment = dataSegment
+
+	var markableSegment int
+	for segment, count := range mh.pendingDataSegments {
+		if segment >= dataSegment || count > 0 {
+			continue
+		}
+
+		if segment > markableSegment {
+			markableSegment = segment
+		}
+
+		// Clean up the pending map: the current segment has been completely
+		// consumed and doesn't need to be considered for marking again.
+		delete(mh.pendingDataSegments, segment)
+	}
+
+	if markableSegment > mh.lastMarkedSegment {
+		mh.markerFileHandler.MarkSegment(markableSegment)
+		mh.lastMarkedSegment = markableSegment
+	}
+}
+
+// processConsumedData updates a counter for how many samples have been sent for each segment.
+// "data" is a map of segment index to consumed data count (e.g. number of samples).
+func (mh *markerHandler) ProcessConsumedData(data map[int]int) {
+	mh.pendingDataMut.Lock()
+	defer mh.pendingDataMut.Unlock()
+
+	for segment, count := range data {
+		if _, tracked := mh.pendingDataSegments[segment]; !tracked {
+			//TODO: How is it possible to not track it? This should log an error?
+			continue
+		}
+		mh.pendingDataSegments[segment] -= count
+	}
+}
+
+func (mh *markerHandler) Stop() {
+	mh.markerFileHandler.Stop()
+}

--- a/storage/remote/marker_handler.go
+++ b/storage/remote/marker_handler.go
@@ -1,24 +1,29 @@
 package remote
 
 import (
-	"sync"
-
 	"github.com/prometheus/prometheus/tsdb/wlog"
 )
 
 type MarkerHandler interface {
 	wlog.Marker
-	UpdatePendingData(dataCount, dataSegment int)
-	ProcessConsumedData(data map[int]int)
+
+	UpdateReceivedData(segmentId, dataCount int) // Data queued for sending
+	UpdateSentData(segmentId, dataCount int)     // Data which was sent or given up on sending
+
 	Stop()
 }
 
 type markerHandler struct {
-	markerFileHandler   MarkerFileHandler
-	pendingDataMut      sync.Mutex
-	latestDataSegment   int
-	lastMarkedSegment   int
-	pendingDataSegments map[int]int // Map of segment index to pending count
+	markerFileHandler MarkerFileHandler
+	lastMarkedSegment int
+	dataIOUpdate      chan data
+	quit              chan struct{}
+}
+
+// TODO: Rename this struct
+type data struct {
+	segmentId int
+	dataCount int
 }
 
 var (
@@ -27,16 +32,20 @@ var (
 
 func NewMarkerHandler(mfh MarkerFileHandler) MarkerHandler {
 	mh := &markerHandler{
-		latestDataSegment:   -1,
-		lastMarkedSegment:   -1,
-		pendingDataSegments: make(map[int]int),
-		markerFileHandler:   mfh,
+		lastMarkedSegment: -1, // Segment ID last marked on disk.
+		markerFileHandler: mfh,
+		//TODO: What is a good size for the channel?
+		dataIOUpdate: make(chan data, 100),
+		quit:         make(chan struct{}),
 	}
 
 	// Load the last marked segment from disk (if it exists).
 	if lastSegment := mh.markerFileHandler.LastMarkedSegment(); lastSegment >= 0 {
 		mh.lastMarkedSegment = lastSegment
 	}
+
+	//TODO: Should this be in a separate Start() function?
+	go mh.updatePendingData()
 
 	return mh
 }
@@ -45,68 +54,62 @@ func (mh *markerHandler) LastMarkedSegment() int {
 	return mh.markerFileHandler.LastMarkedSegment()
 }
 
-// updatePendingData updates a counter for how much data is yet to be sent from each segment.
-// "dataCount" will be added to the segment with ID "dataSegment".
-func (mh *markerHandler) UpdatePendingData(dataCount, dataSegment int) {
-	mh.pendingDataMut.Lock()
-	defer mh.pendingDataMut.Unlock()
-
-	mh.pendingDataSegments[dataSegment] += dataCount
-
-	// We want to save segments whose data has been fully processed by the
-	// QueueManager. To avoid too much overhead when appending data, we'll only
-	// examine pending data per segment whenever a new segment is detected.
-	//
-	// This could cause our saved segment to lag behind multiple segments
-	// depending on the rate that new segments are created and how long
-	// data in other segments takes to be processed.
-	if dataSegment <= mh.latestDataSegment {
-		return
-	}
-
-	// We've received data for a new segment. We'll use this as a signal to see
-	// if older segments have been fully processed.
-	//
-	// We want to mark the highest segment which has no more pending data and is
-	// newer than our last mark.
-	mh.latestDataSegment = dataSegment
-
-	var markableSegment int
-	for segment, count := range mh.pendingDataSegments {
-		if segment >= dataSegment || count > 0 {
-			continue
-		}
-
-		if segment > markableSegment {
-			markableSegment = segment
-		}
-
-		// Clean up the pending map: the current segment has been completely
-		// consumed and doesn't need to be considered for marking again.
-		delete(mh.pendingDataSegments, segment)
-	}
-
-	if markableSegment > mh.lastMarkedSegment {
-		mh.markerFileHandler.MarkSegment(markableSegment)
-		mh.lastMarkedSegment = markableSegment
+func (mh *markerHandler) UpdateReceivedData(segmentId, dataCount int) {
+	mh.dataIOUpdate <- data{
+		segmentId: segmentId,
+		dataCount: dataCount,
 	}
 }
 
-// processConsumedData updates a counter for how many samples have been sent for each segment.
-// "data" is a map of segment index to consumed data count (e.g. number of samples).
-func (mh *markerHandler) ProcessConsumedData(data map[int]int) {
-	mh.pendingDataMut.Lock()
-	defer mh.pendingDataMut.Unlock()
-
-	for segment, count := range data {
-		if _, tracked := mh.pendingDataSegments[segment]; !tracked {
-			//TODO: How is it possible to not track it? This should log an error?
-			continue
-		}
-		mh.pendingDataSegments[segment] -= count
+func (mh *markerHandler) UpdateSentData(segmentId, dataCount int) {
+	mh.dataIOUpdate <- data{
+		segmentId: segmentId,
+		dataCount: -1 * dataCount,
 	}
 }
 
 func (mh *markerHandler) Stop() {
+	// Firstly stop the Marker Handler, because it might want to use the Marker File Handler.
+	mh.quit <- struct{}{}
+
+	// Finally, stop the File Handler.
 	mh.markerFileHandler.Stop()
+}
+
+// updatePendingData updates a counter for how much data is yet to be sent from each segment.
+// "dataCount" will be added to the segment with ID "dataSegment".
+func (mh *markerHandler) updatePendingData() {
+	batchSegmentCount := make(map[int]int)
+
+	for {
+		select {
+		case <-mh.quit:
+			return
+		case dataUpdate := <-mh.dataIOUpdate:
+			batchSegmentCount[dataUpdate.segmentId] += dataUpdate.dataCount
+		}
+
+		markableSegment := -1
+		for segment, count := range batchSegmentCount {
+			//TODO: If count is less than 0, then log an error and remove the entry from the map?
+			if count != 0 {
+				continue
+			}
+
+			//TODO: Is it save to assume that just because a segment is 0 inside the map,
+			//      all samples from it have been processed?
+			if segment > markableSegment {
+				markableSegment = segment
+			}
+
+			// Clean up the pending map: the current segment has been completely
+			// consumed and doesn't need to be considered for marking again.
+			delete(batchSegmentCount, segment)
+		}
+
+		if markableSegment > mh.lastMarkedSegment {
+			mh.markerFileHandler.MarkSegment(markableSegment)
+			mh.lastMarkedSegment = markableSegment
+		}
+	}
 }

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -175,6 +175,18 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 			continue
 		}
 
+		logger := rws.logger
+		if logger == nil {
+			logger = log.NewNopLogger()
+		}
+
+		markerFileHandler, err := NewMarkerFileHandler(logger, rws.dir, hash)
+		if err != nil {
+			return err
+		}
+
+		markerHandler := NewMarkerHandler(markerFileHandler)
+
 		// Redacted to remove any passwords in the URL (that are
 		// technically accepted but not recommended) since this is
 		// only used for metric labels.
@@ -183,7 +195,7 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 			newQueueManagerMetrics(rws.reg, name, endpoint),
 			rws.watcherMetrics,
 			rws.liveReaderMetrics,
-			rws.logger,
+			logger,
 			rws.dir,
 			rws.samplesIn,
 			rwConf.QueueConfig,
@@ -197,6 +209,7 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 			rws.scraper,
 			rwConf.SendExemplars,
 			rwConf.SendNativeHistograms,
+			markerHandler,
 		)
 		// Keep track of which queues are new so we know which to start.
 		newHashes = append(newHashes, hash)

--- a/tsdb/wlog/watcher.go
+++ b/tsdb/wlog/watcher.go
@@ -51,23 +51,36 @@ type WriteTo interface {
 	// Append and AppendExemplar should block until the samples are fully accepted,
 	// whether enqueued in memory or successfully written to it's final destination.
 	// Once returned, the WAL Watcher will not attempt to pass that data again.
-	Append([]record.RefSample) bool
-	AppendExemplars([]record.RefExemplar) bool
-	AppendHistograms([]record.RefHistogramSample) bool
-	AppendFloatHistograms([]record.RefFloatHistogramSample) bool
-	StoreSeries([]record.RefSeries, int)
+	Append(samples []record.RefSample, segment int) bool
+	AppendExemplars(exemplars []record.RefExemplar, segment int) bool
+	AppendHistograms(histogramSamples []record.RefHistogramSample, segment int) bool
+	AppendFloatHistograms(floatHistogramSamples []record.RefFloatHistogramSample, segment int) bool
+	StoreSeries(series []record.RefSeries, segment int)
 
 	// Next two methods are intended for garbage-collection: first we call
 	// UpdateSeriesSegment on all current series
-	UpdateSeriesSegment([]record.RefSeries, int)
+	UpdateSeriesSegment(series []record.RefSeries, segment int)
 	// Then SeriesReset is called to allow the deletion
 	// of all series created in a segment lower than the argument.
-	SeriesReset(int)
+	SeriesReset(segment int)
 }
 
 // Used to notifier the watcher that data has been written so that it can read.
 type WriteNotified interface {
 	Notify()
+}
+
+// Marker allows the Watcher to start from a specific segment in the WAL.
+// Implementers can use this interface to save and restore save points.
+type Marker interface {
+	// LastMarkedSegment should return the last segment stored in the marker.
+	// Must return nil if there is no mark.
+	//
+	// The Watcher will start reading the first segment whose value is greater
+	// than the return value.
+	LastMarkedSegment() int
+	//TODO: Can it not just return -1? Is the *int some Go thing? Also, if it's -1 maybe the Watcher will just read from 0?
+	//TODO: Also, we anyway have to check for negative integers because this is not unsigned?
 }
 
 type WatcherMetrics struct {
@@ -82,6 +95,7 @@ type WatcherMetrics struct {
 type Watcher struct {
 	name           string
 	writer         WriteTo
+	marker         Marker
 	logger         log.Logger
 	walDir         string
 	lastCheckpoint string
@@ -92,6 +106,7 @@ type Watcher struct {
 
 	startTime      time.Time
 	startTimestamp int64 // the start time as a Prometheus timestamp
+	savedSegment   int   // Last tailed marker. Overrides startTimestamp.
 	sendSamples    bool
 
 	recordsReadMetric       *prometheus.CounterVec
@@ -169,13 +184,15 @@ func NewWatcherMetrics(reg prometheus.Registerer) *WatcherMetrics {
 }
 
 // NewWatcher creates a new WAL watcher for a given WriteTo.
-func NewWatcher(metrics *WatcherMetrics, readerMetrics *LiveReaderMetrics, logger log.Logger, name string, writer WriteTo, dir string, sendExemplars, sendHistograms bool) *Watcher {
+// Reading will start at the segment returned by marker if marker is non-nil.
+func NewWatcher(metrics *WatcherMetrics, readerMetrics *LiveReaderMetrics, logger log.Logger, name string, writer WriteTo, marker Marker, dir string, sendExemplars, sendHistograms bool) *Watcher {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
 	return &Watcher{
 		logger:         logger,
 		writer:         writer,
+		marker:         marker,
 		metrics:        metrics,
 		readerMetrics:  readerMetrics,
 		walDir:         filepath.Join(dir, "wal"),
@@ -189,6 +206,7 @@ func NewWatcher(metrics *WatcherMetrics, readerMetrics *LiveReaderMetrics, logge
 
 		MaxSegment: -1,
 	}
+	//TODO: Set savedSegment to -1?
 }
 
 func (w *Watcher) Notify() {
@@ -246,7 +264,14 @@ func (w *Watcher) loop() {
 
 	// We may encounter failures processing the WAL; we should wait and retry.
 	for !isClosed(w.quit) {
+		if w.marker != nil {
+			w.savedSegment = w.marker.LastMarkedSegment()
+			//TODO: Does this print the int or the address of the int?
+			level.Debug(w.logger).Log("msg", "last saved segment", "segment", w.savedSegment)
+		}
+
 		w.SetStartTime(time.Now())
+
 		if err := w.Run(); err != nil {
 			level.Error(w.logger).Log("msg", "error tailing WAL", "err", err)
 		}
@@ -568,17 +593,17 @@ func (w *Watcher) readSegment(r *LiveReader, segmentNum int, tail bool) error {
 				return err
 			}
 			for _, s := range samples {
-				if s.T > w.startTimestamp {
+				if w.canSendSamples(segmentNum, s.T) {
 					if !w.sendSamples {
 						w.sendSamples = true
 						duration := time.Since(w.startTime)
-						level.Info(w.logger).Log("msg", "Done replaying WAL", "duration", duration)
+						level.Info(w.logger).Log("msg", "Done replaying WAL", "duration", duration, "segment", segmentNum)
 					}
 					samplesToSend = append(samplesToSend, s)
 				}
 			}
 			if len(samplesToSend) > 0 {
-				w.writer.Append(samplesToSend)
+				w.writer.Append(samplesToSend, segmentNum)
 				samplesToSend = samplesToSend[:0]
 			}
 
@@ -597,7 +622,7 @@ func (w *Watcher) readSegment(r *LiveReader, segmentNum int, tail bool) error {
 				w.recordDecodeFailsMetric.Inc()
 				return err
 			}
-			w.writer.AppendExemplars(exemplars)
+			w.writer.AppendExemplars(exemplars, segmentNum)
 
 		case record.HistogramSamples:
 			// Skip if experimental "histograms over remote write" is not enabled.
@@ -623,7 +648,7 @@ func (w *Watcher) readSegment(r *LiveReader, segmentNum int, tail bool) error {
 				}
 			}
 			if len(histogramsToSend) > 0 {
-				w.writer.AppendHistograms(histogramsToSend)
+				w.writer.AppendHistograms(histogramsToSend, segmentNum)
 				histogramsToSend = histogramsToSend[:0]
 			}
 		case record.FloatHistogramSamples:
@@ -650,7 +675,7 @@ func (w *Watcher) readSegment(r *LiveReader, segmentNum int, tail bool) error {
 				}
 			}
 			if len(floatHistogramsToSend) > 0 {
-				w.writer.AppendFloatHistograms(floatHistogramsToSend)
+				w.writer.AppendFloatHistograms(floatHistogramsToSend, segmentNum)
 				floatHistogramsToSend = floatHistogramsToSend[:0]
 			}
 		case record.Tombstones:
@@ -661,6 +686,16 @@ func (w *Watcher) readSegment(r *LiveReader, segmentNum int, tail bool) error {
 		}
 	}
 	return errors.Wrapf(r.Err(), "segment %d: %v", segmentNum, r.Err())
+}
+
+// TODO: Add a function description
+func (w *Watcher) canSendSamples(segmentNum int, ts int64) bool {
+	//TODO: What if we have already replayed the WAL? Then segmentNum > *w.savedSegment
+	//      will always return true, and we will never get to ts > w.startTimestamp?
+	if w.savedSegment >= 0 && segmentNum > w.savedSegment {
+		return true
+	}
+	return ts > w.startTimestamp
 }
 
 // Go through all series in a segment updating the segmentNum, so we can delete older series.

--- a/tsdb/wlog/watcher.go
+++ b/tsdb/wlog/watcher.go
@@ -79,8 +79,6 @@ type Marker interface {
 	// The Watcher will start reading the first segment whose value is greater
 	// than the return value.
 	LastMarkedSegment() int
-	//TODO: Can it not just return -1? Is the *int some Go thing? Also, if it's -1 maybe the Watcher will just read from 0?
-	//TODO: Also, we anyway have to check for negative integers because this is not unsigned?
 }
 
 type WatcherMetrics struct {
@@ -199,6 +197,7 @@ func NewWatcher(metrics *WatcherMetrics, readerMetrics *LiveReaderMetrics, logge
 		name:           name,
 		sendExemplars:  sendExemplars,
 		sendHistograms: sendHistograms,
+		savedSegment:   -1,
 
 		readNotify: make(chan struct{}),
 		quit:       make(chan struct{}),
@@ -206,7 +205,6 @@ func NewWatcher(metrics *WatcherMetrics, readerMetrics *LiveReaderMetrics, logge
 
 		MaxSegment: -1,
 	}
-	//TODO: Set savedSegment to -1?
 }
 
 func (w *Watcher) Notify() {
@@ -266,7 +264,6 @@ func (w *Watcher) loop() {
 	for !isClosed(w.quit) {
 		if w.marker != nil {
 			w.savedSegment = w.marker.LastMarkedSegment()
-			//TODO: Does this print the int or the address of the int?
 			level.Debug(w.logger).Log("msg", "last saved segment", "segment", w.savedSegment)
 		}
 

--- a/tsdb/wlog/watcher_test.go
+++ b/tsdb/wlog/watcher_test.go
@@ -60,22 +60,22 @@ type writeToMock struct {
 	seriesSegmentIndexes    map[chunks.HeadSeriesRef]int
 }
 
-func (wtm *writeToMock) Append(s []record.RefSample) bool {
+func (wtm *writeToMock) Append(s []record.RefSample, segment int) bool {
 	wtm.samplesAppended += len(s)
 	return true
 }
 
-func (wtm *writeToMock) AppendExemplars(e []record.RefExemplar) bool {
+func (wtm *writeToMock) AppendExemplars(e []record.RefExemplar, segment int) bool {
 	wtm.exemplarsAppended += len(e)
 	return true
 }
 
-func (wtm *writeToMock) AppendHistograms(h []record.RefHistogramSample) bool {
+func (wtm *writeToMock) AppendHistograms(h []record.RefHistogramSample, segment int) bool {
 	wtm.histogramsAppended += len(h)
 	return true
 }
 
-func (wtm *writeToMock) AppendFloatHistograms(fh []record.RefFloatHistogramSample) bool {
+func (wtm *writeToMock) AppendFloatHistograms(fh []record.RefFloatHistogramSample, segment int) bool {
 	wtm.floatHistogramsAppended += len(fh)
 	return true
 }
@@ -210,7 +210,7 @@ func TestTailSamples(t *testing.T) {
 			require.NoError(t, err)
 
 			wt := newWriteToMock()
-			watcher := NewWatcher(wMetrics, nil, nil, "", wt, dir, true, true)
+			watcher := NewWatcher(wMetrics, nil, nil, "", wt, nil, dir, true, true)
 			watcher.SetStartTime(now)
 
 			// Set the Watcher's metrics so they're not nil pointers.
@@ -295,7 +295,7 @@ func TestReadToEndNoCheckpoint(t *testing.T) {
 			require.NoError(t, err)
 
 			wt := newWriteToMock()
-			watcher := NewWatcher(wMetrics, nil, nil, "", wt, dir, false, false)
+			watcher := NewWatcher(wMetrics, nil, nil, "", wt, nil, dir, false, false)
 			go watcher.Start()
 
 			expected := seriesCount
@@ -384,7 +384,7 @@ func TestReadToEndWithCheckpoint(t *testing.T) {
 			require.NoError(t, err)
 			readTimeout = time.Second
 			wt := newWriteToMock()
-			watcher := NewWatcher(wMetrics, nil, nil, "", wt, dir, false, false)
+			watcher := NewWatcher(wMetrics, nil, nil, "", wt, nil, dir, false, false)
 			go watcher.Start()
 
 			expected := seriesCount * 2
@@ -455,7 +455,7 @@ func TestReadCheckpoint(t *testing.T) {
 			require.NoError(t, err)
 
 			wt := newWriteToMock()
-			watcher := NewWatcher(wMetrics, nil, nil, "", wt, dir, false, false)
+			watcher := NewWatcher(wMetrics, nil, nil, "", wt, nil, dir, false, false)
 			go watcher.Start()
 
 			expectedSeries := seriesCount
@@ -524,7 +524,7 @@ func TestReadCheckpointMultipleSegments(t *testing.T) {
 			}
 
 			wt := newWriteToMock()
-			watcher := NewWatcher(wMetrics, nil, nil, "", wt, dir, false, false)
+			watcher := NewWatcher(wMetrics, nil, nil, "", wt, nil, dir, false, false)
 			watcher.MaxSegment = -1
 
 			// Set the Watcher's metrics so they're not nil pointers.
@@ -597,7 +597,7 @@ func TestCheckpointSeriesReset(t *testing.T) {
 
 			readTimeout = time.Second
 			wt := newWriteToMock()
-			watcher := NewWatcher(wMetrics, nil, nil, "", wt, dir, false, false)
+			watcher := NewWatcher(wMetrics, nil, nil, "", wt, nil, dir, false, false)
 			watcher.MaxSegment = -1
 			go watcher.Start()
 


### PR DESCRIPTION
This PR is based on the work in [#9862](https://github.com/prometheus/prometheus/pull/9862):

* The main [objection](https://github.com/prometheus/prometheus/pull/9862#pullrequestreview-886692698) with the original PR is that some functionality is synchronous and requires locking. With this PR, I tried to take a more asyncronous approach.
* The marker file in the original PR was named after the client ID. In this PR we use the hash of the queue config.
  * The client ID may contain characters which are not valid names for a file or directory. I think this is not the case at the moment, because the client ID has to be a valid Prometheus label and all such labels should be valid file paths. But I think it's better not to count on this.
  * By using the hash, if any part of the client config changes, we will have a new marker file. This probably makes sense in the general case. For example, if write_relabel_configs changes between restarts, we will not be sending the same metrics.

A few open questions:
* Is the new approach concurrent enough? Would it still block too often?
* Do we still need benchmarks?
* Should we document the new marker files and marker directories somewhere?
* Should we version the marker file structure somehow?
* Should we detect unused marker files/directories and delete them?
* Do we need to add new metrics?
* What if the marker file gets corrupted, e.g. if Prometheus crashes during the time when we write it? We could detect a crash by the presence of a .tmp file, which should swap the main marker file?

There are also additional open questions in TODOs in the code.

I believe that the async behaviour here is a good tradeoff:
* It allows remote write performance to be as close as possible to what it was prior this change
* Even if the marker is a little old, the worst case is that we will just replay a few segments more than necessary. But replaying more than necessary will pretty much always be the case even if the marker is relatively new.

Also note that I haven't written tests yet. I'll write them if we agree that this approach has potential.